### PR TITLE
Support other dbs

### DIFF
--- a/twitter_stream/models.py
+++ b/twitter_stream/models.py
@@ -1,4 +1,5 @@
 from django.db import models, connection
+from django.conf import settings as django_settings
 from datetime import datetime, timedelta
 from email.utils import parsedate
 from django.utils import timezone
@@ -299,15 +300,18 @@ class AbstractTweet(models.Model):
         Get the approximate number of tweets.
         Executes quickly, even on large InnoDB tables.
         """
-        query = "SHOW TABLE STATUS WHERE Name = %s"
-        cursor = connection.cursor()
-        cursor.execute(query, [cls._meta.db_table])
+        if django_settings.DATABASES['default']['ENGINE'].endswith('mysql'):
+            query = "SHOW TABLE STATUS WHERE Name = %s"
+            cursor = connection.cursor()
+            cursor.execute(query, [cls._meta.db_table])
 
-        desc = cursor.description
-        row = cursor.fetchone()
-        row = dict(zip([col[0].lower() for col in desc], row))
+            desc = cursor.description
+            row = cursor.fetchone()
+            row = dict(zip([col[0].lower() for col in desc], row))
 
-        return int(row['rows'])
+            return int(row['rows'])
+        else:
+            return len(cls.objects.all())
 
 class Tweet(AbstractTweet):
     """

--- a/twitter_stream/views.py
+++ b/twitter_stream/views.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 import json
+from django.conf import settings
 from django.utils import timezone
 from django.template import RequestContext
 from django.template.loader import render_to_string
@@ -44,8 +45,15 @@ def stream_status():
     if latest_time is not None:
         latest_time_minute = latest_time.replace(second=0, microsecond=0)
 
+        if settings.DATABASES['default']['ENGINE'].endswith('mysql'):
+            drop_seconds = "created_at - INTERVAL SECOND(created_at) SECOND"
+        elif settings.DATABASES['default']['ENGINE'].endswith('postgresql_psycopg2'):
+            drop_seconds = "date_trunc('minute', created_at + interval '30 second')"
+        else:
+            drop_seconds = "created_at"
+
         tweet_counts = Tweet.objects.extra(select={
-            'time': "created_at - INTERVAL SECOND(created_at) SECOND"
+            'time': drop_seconds
         }) \
             .filter(created_at__gt=latest_time_minute - timedelta(minutes=20)) \
             .values('time') \

--- a/twitter_stream/views.py
+++ b/twitter_stream/views.py
@@ -48,7 +48,7 @@ def stream_status():
         if settings.DATABASES['default']['ENGINE'].endswith('mysql'):
             drop_seconds = "created_at - INTERVAL SECOND(created_at) SECOND"
         elif settings.DATABASES['default']['ENGINE'].endswith('postgresql_psycopg2'):
-            drop_seconds = "date_trunc('minute', created_at + interval '30 second')"
+            drop_seconds = "date_trunc('minute', created_at)"
         else:
             drop_seconds = "created_at"
 


### PR DESCRIPTION
django-twitter-stream only supports mysql.  I’ve added basic support for Postgres.  For other databases, StatusView fallsback to using “created_at” for “time”.
